### PR TITLE
Custom domain means changing base path

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,11 +1,14 @@
 name: Build and Deploy
 
+# For development, just run on push to any branch
+on: push
 # Runs build and deploy whenever main is merged to or pushed to.
 # (...please don't push directly to main)
-on:
-  push:
-    branches:
-      - main
+# VOODOO Revert to below
+# on:
+#   push:
+#     branches:
+#       - main
 
 jobs:
   build_and_deploy:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,14 +1,11 @@
 name: Build and Deploy
 
-# For development, just run on push to any branch
-on: push
 # Runs build and deploy whenever main is merged to or pushed to.
 # (...please don't push directly to main)
-# VOODOO Revert to below
-# on:
-#   push:
-#     branches:
-#       - main
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build_and_deploy:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -25,13 +25,8 @@ jobs:
         # `npm ci` tells npm to install matching against package-lock file
         run: npm ci
       - name: Build app
-        env:
-          # This is not really a "secret", just a way to get per-repo env vars.
-          # Annoyingly (but reasonable), GitHub redacts this from logs, so you
-          # won't be able to see the build mode by reading the Action's logs.
-          GALAGO_VITE_BUILD_MODE: ${{ secrets.GALAGO_VITE_BUILD_MODE }}
         # As configured in Aug 2022, `vite build` outputs to `dist` folder.
-        run: npm run build -- --mode $GALAGO_VITE_BUILD_MODE
+        run: npm run build
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/src/components/landingPage/demo.tsx
+++ b/src/components/landingPage/demo.tsx
@@ -2,7 +2,7 @@ import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@mui/material";
 import { Theme } from "../../theme";
-import { PATH_TO_APP } from "../../routes";
+import { ROUTES } from "../../routes";
 
 type DemoProps = {
   sectionWidth: number;
@@ -47,7 +47,7 @@ export const Demo = (props: DemoProps) => {
           disableRipple
           onClick={() => {
             dispatch({ type: "load demo" });
-            navigate(PATH_TO_APP);
+            navigate(ROUTES.APP);
           }}
           size="large"
         >

--- a/src/components/landingPage/uploadModal.tsx
+++ b/src/components/landingPage/uploadModal.tsx
@@ -24,7 +24,7 @@ import {
   Select,
 } from "@mui/material";
 import PathogenSelection from "./pathogenSelection";
-import { PATH_TO_APP } from "../../routes";
+import { ROUTES } from "../../routes";
 
 export const UploadModal = () => {
   // @ts-ignore -- one day I will learn how to `type` all my state variables, but that day is not today
@@ -187,7 +187,7 @@ export const UploadModal = () => {
           disableRipple
           onClick={(e) => {
             dispatch({ type: "upload submit button clicked" });
-            navigate(PATH_TO_APP);
+            navigate(ROUTES.APP);
           }}
           disabled={
             !state.division ||

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,7 @@ import { store } from "./reducers/store";
 import LandingPageRoute from "./routes/landingPageRoute";
 import { ThemeProvider } from "@emotion/react";
 import { Theme } from "./theme";
-import { PATH_TO_HOMEPAGE, PATH_TO_APP } from "./routes";
+import { ROUTES } from "./routes";
 
 ReactDOM.render(
   <React.StrictMode>
@@ -17,8 +17,8 @@ ReactDOM.render(
       <ThemeProvider theme={Theme}>
         <BrowserRouter>
           <Routes>
-            <Route path={PATH_TO_HOMEPAGE} element={<LandingPageRoute />} />
-            <Route path={PATH_TO_APP} element={<App />} />
+            <Route path={ROUTES.HOMEPAGE} element={<LandingPageRoute />} />
+            <Route path={ROUTES.APP} element={<App />} />
           </Routes>
         </BrowserRouter>
       </ThemeProvider>

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -37,6 +37,8 @@ const BASE_WITHOUT_TRAILING_SLASH = BASE_URL.slice(0, -1);
  * and we can just go to directly using our ROUTES values in app.
  */
 function getRoutePath(route: ROUTES) {
+  console.log("import.meta.env.BASE_URL", import.meta.env.BASE_URL); // REMOVE
+  console.log("BASE_WITHOUT_TRAILING_SLASH", BASE_WITHOUT_TRAILING_SLASH); // REMOVE
   return BASE_WITHOUT_TRAILING_SLASH + route;
 }
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,46 +1,21 @@
 /**
  * Contains all routes / paths for the application.
  *
- * Generally, at the bottom of this file you can find the `PATH_` you want
- * for any app route. Right now, I think that will be enough, but there
- * might be some edge case down the road that makes us need to export
- * the ROUTES and getRoutePath for direct use in a component. If that happens,
- * not an issue to export them and generate paths dynamically.
+ * For any dev writing route interactions, you can just import ROUTES then
+ * refer to the needed route with, eg, `ROUTES.APP`, etc, etc. If you need
+ * to add a new route, add it here first then use that import in whatever
+ * routing code you're writing. You should -- unless absolutely necessary --
+ * avoid directly writing a raw string of the route somewhere in code; instead
+ * route strings should just be pointing at the various values in ROUTES here.
  *
- * Because of how we currently handle deploying the same code to different
- * repos -- a forked "Staging" repo and a "Prod" repo -- we need a little bit
- * of fanciness to avoid the static site aspect of GitHub Pages breaking
- * depending on which repo we're deploying from.
+ * In the past, this file required more complexity because we were serving
+ * the app via GitHub Pages but /not/ using a custom domain. This made it
+ * necessary to dynamically configure the `base` path part of the URL, which
+ * then meant we had to abstract away building our routes out of that base
+ * path plus the "real" value in ROUTES. If we ever have to go back to that
+ * approach, look at commit SHA `0c4f251c` for this file and `vite.config.ts`.
  */
-enum ROUTES {
+export enum ROUTES {
   HOMEPAGE = "/",
   APP = "/app",
 }
-
-// BASE_URL from vite always includes trailing slash. Chop that off so our
-// routes can have the prefixed slash to make them easier for devs to read.
-// `import.meta.env.BASE_URL` is interpolated by vite, see docs:
-//   https://vitejs.dev/guide/env-and-mode.html
-const BASE_URL = import.meta.env.BASE_URL;
-const BASE_WITHOUT_TRAILING_SLASH = BASE_URL.slice(0, -1);
-
-
-/**
- * Gets the appropriate path for a given route.
- *
- * Necessary due to how GitHub Pages and base URL works. This abstracts all
- * that away so we can just set the appropriate base URL in our vite config
- * based on the GitHub repo our GH Page is connected to, then use this func
- * plus the `ROUTES` above to generate all the app routes.
- *
- * When we move to a custom domain for our GH Pages, this might get broken
- * and we can just go to directly using our ROUTES values in app.
- */
-function getRoutePath(route: ROUTES) {
-  console.log("import.meta.env.BASE_URL", import.meta.env.BASE_URL); // REMOVE
-  console.log("BASE_WITHOUT_TRAILING_SLASH", BASE_WITHOUT_TRAILING_SLASH); // REMOVE
-  return BASE_WITHOUT_TRAILING_SLASH + route;
-}
-
-export const PATH_TO_HOMEPAGE = getRoutePath(ROUTES.HOMEPAGE);
-export const PATH_TO_APP = getRoutePath(ROUTES.APP);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -13,7 +13,8 @@
  * necessary to dynamically configure the `base` path part of the URL, which
  * then meant we had to abstract away building our routes out of that base
  * path plus the "real" value in ROUTES. If we ever have to go back to that
- * approach, look at commit SHA `0c4f251c` for this file and `vite.config.ts`.
+ * approach, look at commit SHA `0c4f251c` for this file, `vite.config.ts` and
+ * the GitHub workflow itself `.github/workflows/build-deployment.yml`.
  */
 export enum ROUTES {
   HOMEPAGE = "/",

--- a/src/routes/landingPageRoute.tsx
+++ b/src/routes/landingPageRoute.tsx
@@ -2,8 +2,6 @@ import Header from "../components/header";
 import LandingPage from "../components/landingPage";
 
 export const LandingPageRoute = () => {
-  console.log("Please be a prod build"); // REMOVE
-  console.log("import metaXenvXMODE", import.meta.env.MODE); // REMOVE
   return (
     <div>
       <Header />

--- a/src/routes/landingPageRoute.tsx
+++ b/src/routes/landingPageRoute.tsx
@@ -2,7 +2,7 @@ import Header from "../components/header";
 import LandingPage from "../components/landingPage";
 
 export const LandingPageRoute = () => {
-  console.log("CI/CD appears to be working as expected!"); // REMOVE
+  console.log("Routes swapped over. Yay root domains!"); // REMOVE
   return (
     <div>
       <Header />

--- a/src/routes/landingPageRoute.tsx
+++ b/src/routes/landingPageRoute.tsx
@@ -2,7 +2,8 @@ import Header from "../components/header";
 import LandingPage from "../components/landingPage";
 
 export const LandingPageRoute = () => {
-  console.log("Routes swapped over. Yay root domains!"); // REMOVE
+  console.log("Please be a prod build"); // REMOVE
+  console.log("import metaXenvXMODE", import.meta.env.MODE); // REMOVE
   return (
     <div>
       <Header />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,13 +18,6 @@ const STAGING_KEYWORD = "staging"; // Running in galago-labs
  * env var that GitHub Action passes by introspecting the repo name. But
  * also possible that having custom domain names will make all this unneeded.
  */
-export default defineConfig(({mode}) => {
-  let basePath = "/galago/";
-  if (mode.toLowerCase() === STAGING_KEYWORD) {
-    basePath = "/galago-labs/";
-  }
-  return {
-    plugins: [react()],
-    base: basePath,
-  };
+export default defineConfig({
+  plugins: [react()],
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,8 @@ import react from "@vitejs/plugin-react";
  * However, when we were serving the app via GitHub Pages but /not/ using a
  * custom domain, it was necessary to dynamically configure the `base` path
  * part of the URL. If we ever have to go back to this approach, look at
- * commit SHA `0c4f251c` for this file and src/routes/index.ts.
+ * commit SHA `0c4f251c` for this file, `src/routes/index.ts`, and the GitHub
+ * workflow itself `.github/workflows/build-deployment.yml`.
  */
 export default defineConfig({
   plugins: [react()],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-const STAGING_KEYWORD = "staging"; // Running in galago-labs
-
 /**
  * Generate config for vite. Docs -- https://vitejs.dev/config/
  *
@@ -11,12 +9,11 @@ const STAGING_KEYWORD = "staging"; // Running in galago-labs
  * to have the config accept a function that takes `mode` (and other args if
  * desired) and returns the config after any logic is done.
  *
- * This is necessary because our staging and prod versions of the app get
- * served from different URLs so we inject that here. We are relying on the
- * fact that we explicitly know the names of the Prod and Staging repos. If
- * we needed to truly generalize, would want to set from some kind of real
- * env var that GitHub Action passes by introspecting the repo name. But
- * also possible that having custom domain names will make all this unneeded.
+ * Currently, this is not needed for us and we're fine with a static config.
+ * However, when we were serving the app via GitHub Pages but /not/ using a
+ * custom domain, it was necessary to dynamically configure the `base` path
+ * part of the URL. If we ever have to go back to this approach, look at
+ * commit SHA `0c4f251c` for this file and src/routes/index.ts.
  */
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
Previously, we had put in work to handle the base path aspect of URL with how GitHub Pages work (`blah.com/galago-labs/` as the root, etc). However, now that we have a custom domain, everything gets served from the root of domain like an ordinary site, so needed to rip out all the base path stuff. Has the added benefit of making our deploy process simpler -- no need to track a the Vite build mode, both staging galago-labs and prod galago repos build to the same `production` NODE_ENV targer, etc -- so that's nice.

If this ever needs to be reverted because we go back to serving them as "normal" GitHub pages with an embedded base path of the repo in the URL, would pretty much want to go back and reverse the work done in this PR. I also left some docs referencing the commit (`0c4f251c`) where the base path stuff was in place also so it's possible discover how to go back without needing to re-learn how GitHub Pages and routing works.