### PR TITLE
Add JSON file for easy dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ stub_data
 *.ipynb
 .vscode
 data/*.json
+# Below line is temporary while we want to make specific json public for dev
 !data/temp_dev_demo_tree.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ stub_data
 *.ipynb
 .vscode
 data/*.json
+!data/temp_dev_demo_tree.json


### PR DESCRIPTION
Adds a real tree JSON file to the repo as a temporary way to make a JSON available at public URL (via GitHub raw content URL) while also making it track-able. This data is the same as the current demo tree data, it's just presented as a JSON file instead of as a javascript importable object.