### PR TITLE
Disable sampling bias insight in report if the pathogen isn't SARS-CoV-2

### DIFF
--- a/src/components/report/index.tsx
+++ b/src/components/report/index.tsx
@@ -53,11 +53,14 @@ export const Report = (props: ReportProps) => {
           <TMRCA sidenote_start={3} />
           <OnwardTransmission />
           <GeoSubclades />
-          <SamplingBias
-            // @ts-ignore
-            gisaidCounts={gisaidCounts}
-            sidenote_start={7}
-          />
+          {state.pathogen === "sarscov2" && (
+            // TODO: rewrite this to still be accurate and valuable for pathogens w/o reference data available
+            <SamplingBias
+              // @ts-ignore
+              gisaidCounts={gisaidCounts}
+              sidenote_start={7}
+            />
+          )}
           <Assumptions sidenote_start={8} />
         </>
       )}

--- a/src/components/viz/cladeSelection/scatterplotLegend.tsx
+++ b/src/components/viz/cladeSelection/scatterplotLegend.tsx
@@ -25,7 +25,7 @@ export const CladeSelectionVizLegend = () => {
           strokeWidth={1}
         />
         <text x="10" y="50" fontSize={14}>
-          Samples in active cluster
+          Other samples in active cluster
         </text>
         <g transform={`translate(0,66.5)`}>
           <line

--- a/src/reducers/global.ts
+++ b/src/reducers/global.ts
@@ -171,6 +171,7 @@ export const global = (state = defaultState, action: any) => {
       return {
         ...defaultState,
         tree: tree,
+        pathogen: "sarscov2",
         haveInternalNodeDates: haveInternalNodeDates,
         metadataEntries: tidyMetadata,
         metadataCensus: { ...treeMetadata, ...metadataCensus },


### PR DESCRIPTION
We don't currently update counts for any other pathogen's public repository; on the to-do list eventually