### PR TITLE
Bugfix: GitHub Actions out of memory

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,13 +1,11 @@
 name: Build and Deploy
 
-on: push
-# TODO Return to below, ^^^ just for debugging test
-# # Runs build and deploy whenever main is merged to or pushed to.
-# # (...please don't push directly to main)
-# on:
-#   push:
-#     branches:
-#       - main
+# Runs build and deploy whenever main is merged to or pushed to.
+# (...please don't push directly to main)
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build_and_deploy:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,11 +1,13 @@
 name: Build and Deploy
 
-# Runs build and deploy whenever main is merged to or pushed to.
-# (...please don't push directly to main)
-on:
-  push:
-    branches:
-      - main
+on: push
+# TODO Return to below, ^^^ just for debugging test
+# # Runs build and deploy whenever main is merged to or pushed to.
+# # (...please don't push directly to main)
+# on:
+#   push:
+#     branches:
+#       - main
 
 jobs:
   build_and_deploy:
@@ -28,6 +30,10 @@ jobs:
           echo Setting up Vite env vars file
           echo "$GALAGO_VITE_ENV_VARS" > .env
       - name: Build app
+        # Saw issues with build running out of memory in GitHub Actions
+        # Resolve per https://github.com/actions/runner-images/issues/70
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'
         # As configured in Aug 2022, `vite build` outputs to `dist` folder.
         run: npm run build
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
For some reason, GitHub Actions started running out of memory during node build step. Unclear what triggered the change in memory usage during build, but found a command line option that caps memory usage. Running a GHA with that in place worked fine, so appears to fix our problem.

Note: The flag we're using is a ["V8 CLI Option"](https://nodejs.org/api/cli.html#useful-v8-options) (I don't know what that means offhand, I don't know Node that well), and there's this caveat in there:
> V8's options have no stability guarantee. The V8 team themselves don't consider them to be part of their formal API, and reserve the right to change them at any time. Likewise, they are not covered by the Node.js stability guarantees. Many of the V8 options are of interest only to V8 developers.

That said, the references I saw when looking for how to fix this issue weren't super recent, so it appears this fix for GHA has been working for a couple years, so we're probably in no danger. Just if it suddenly starts breaking again, look into if that flag stopped being supported in addition to the rest of your bughunting. But hopefully it won't be an issue.