### PR TITLE
Fetch route supports search params

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -31,7 +31,7 @@ jobs:
         # Saw issues with build running out of memory in GitHub Actions
         # Resolve per https://github.com/actions/runner-images/issues/70
         env:
-          NODE_OPTIONS: '--max-old-space-size=4096'
+          NODE_OPTIONS: "--max-old-space-size=4096"
         # As configured in Aug 2022, `vite build` outputs to `dist` folder.
         run: npm run build
       - name: Deploy to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ https://galago.czgenepi.org/#/fetch/example.com/sometree.json
 
 The above example would load Galago using the tree file specified at `https://example.com/sometree.json`. When no `http[s]` schema is present in the given URL, it automatically assumes it is an `https` schema. If you would like to specify the schema, you can enter it in the URL. For example, `https://galago.czgenepi.org/#/fetch/http://example.com/another/tree/route` would also be valid.
 
+### Specifying additional details about public data source
+
+In addition to fetching a publicly available JSON tree via the `fetch` path, you can specify additional, **optional** pieces of information about the tree through the use of [search (AKA query) params](https://en.wikipedia.org/wiki/Query_string). For example:
+
+```
+https://galago.czgenepi.org/#/fetch/example.com/sometree.json?galagoPathogen=sarscov2&galagoMrca=Node47
+```
+
+This feature is still under active development. You can read more about its usage and what params are currently implemented by reading the [source code documentation](/src/utils/fetchData.ts) where it's implemented.
+
 ## Development Process
 
 ```

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -33,11 +33,6 @@ const Header = (props: HeaderProps) => {
       }
     );
   });
-  console.log(
-    "should show errors",
-    errorTypesToDisplay,
-    state.showErrorMessages
-  );
 
   return (
     <div

--- a/src/reducers/global.ts
+++ b/src/reducers/global.ts
@@ -480,6 +480,10 @@ export const global = (state = defaultState, action: any) => {
       const divisionOptions = get_division_input_options(tree, state.country);
       const treeMetadata = treeMetadataCensus(tree);
       const cladeSliderField = haveInternalNodeDates ? "num_date" : "div";
+
+      const lowercasedPathogen = pathogenParam
+        ? pathogenParam.toLowerCase()
+        : "";
       return {
         ...state,
         tree: tree,
@@ -500,7 +504,9 @@ export const global = (state = defaultState, action: any) => {
         metadataCensus: { ...state.metadataCensus, ...treeMetadata },
         // Added portion for Fetch aspect starts here
         uploadModalOpen: true,
-        pathogen: pathogenParam || defaultState.pathogen,
+        pathogen: Object.keys(pathogenParameters).includes(lowercasedPathogen)
+          ? lowercasedPathogen
+          : "other",
         fetchData: {
           ...state.fetchData,
           fetchInProcess: false,

--- a/src/reducers/global.ts
+++ b/src/reducers/global.ts
@@ -30,6 +30,7 @@ import {
   pathogenParameters,
 } from "../utils/pathogenParameters";
 import { showErrorDefaults } from "src/utils/errorTypes";
+import { GalagoParams } from "src/utils/fetchData";
 
 const defaultState = {
   samplesOfInterestNames: [], // literally just the names of the samplesOfInterest
@@ -469,9 +470,13 @@ export const global = (state = defaultState, action: any) => {
     }
 
     case ACTION_TYPES.FETCH_TREE_DATA_SUCCEEDED: {
-      // Almost entirely a copy of type "tree file uploaded"
-      // Just adds tracking fetch and auto-open of upload modal
+      // Primarily a copy of type "tree file uploaded", but fetch specific.
+      // Handles query params, auto-open of upload modal, and fetch completion
       const { tree, haveInternalNodeDates, treeTitle } = action.data;
+      const {
+        pathogen: pathogenParam,
+        // mrca: mrcaParam, TODO Uncomment and use when ready to handle
+      } = action.galagoParams as GalagoParams;
       const divisionOptions = get_division_input_options(tree, state.country);
       const treeMetadata = treeMetadataCensus(tree);
       const cladeSliderField = haveInternalNodeDates ? "num_date" : "div";
@@ -491,10 +496,11 @@ export const global = (state = defaultState, action: any) => {
         ),
         cladeSliderField: cladeSliderField,
         cladeSliderValue: formatMrcaSliderOptionValue(tree, cladeSliderField),
-        mrca: tree,
+        mrca: tree, // TODO should be informed by mrcaParam from search params
         metadataCensus: { ...state.metadataCensus, ...treeMetadata },
         // Added portion for Fetch aspect starts here
         uploadModalOpen: true,
+        pathogen: pathogenParam || defaultState.pathogen,
         fetchData: {
           ...state.fetchData,
           fetchInProcess: false,

--- a/src/routes/fetchTree.tsx
+++ b/src/routes/fetchTree.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import axios from "axios";
-import { getTargetUrlAndParams } from "../utils/fetchData";
+import { getTargetUrlAndParams, GalagoParams } from "../utils/fetchData";
 import LandingPageRoute from "./landingPageRoute";
 import { ACTION_TYPES } from "../reducers/actionTypes";
 import {
@@ -30,7 +30,11 @@ import { maxFileSize } from "../utils/dataIngest";
  * need a way to know which json type we're trying to ingest. Maybe we could
  * determine it from structure of json and auto-choose?
  */
-async function handleDataFetch(targetUrl: string, dispatch: Function) {
+async function handleDataFetch(
+  targetUrl: string,
+  galagoParams: GalagoParams,
+  dispatch: Function,
+) {
   let response; // Here because of `try` block scope.
   try {
     response = await axios.get(targetUrl, { maxBodyLength: maxFileSize });
@@ -47,6 +51,7 @@ async function handleDataFetch(targetUrl: string, dispatch: Function) {
     dispatch({
       type: ACTION_TYPES.FETCH_TREE_DATA_SUCCEEDED,
       data: ingestedNextstrain,
+      galagoParams, // reducer handles interpretation and usage of params
     });
   } catch {
     dispatch({ type: ACTION_TYPES.SHOW_TREE_FORMAT_ERROR });
@@ -65,14 +70,14 @@ const FetchTree = () => {
 
   // Fires off when page mounts to handle process of fetching external JSON.
   useEffect(() => {
-    const targetUrl = getUrlToFetch();
+    const {targetUrl, galagoParams} = getTargetUrlAndParams();
     if (targetUrl) {
       dispatch({
         type: ACTION_TYPES.FETCH_TREE_DATA_STARTED,
         targetUrl,
       });
       // If successful, will load data into tree and open modal for next step
-      handleDataFetch(targetUrl, dispatch);
+      handleDataFetch(targetUrl, galagoParams, dispatch);
     } else {
       // Showed up at /fetch, but no URL given after that. Can't do anything.
       dispatch({

--- a/src/routes/fetchTree.tsx
+++ b/src/routes/fetchTree.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import axios from "axios";
-import { getUrlToFetch } from "../utils/fetchData";
+import { getTargetUrlAndParams } from "../utils/fetchData";
 import LandingPageRoute from "./landingPageRoute";
 import { ACTION_TYPES } from "../reducers/actionTypes";
 import {

--- a/src/routes/fetchTree.tsx
+++ b/src/routes/fetchTree.tsx
@@ -33,7 +33,7 @@ import { maxFileSize } from "../utils/dataIngest";
 async function handleDataFetch(
   targetUrl: string,
   galagoParams: GalagoParams,
-  dispatch: Function,
+  dispatch: Function
 ) {
   let response; // Here because of `try` block scope.
   try {
@@ -70,7 +70,7 @@ const FetchTree = () => {
 
   // Fires off when page mounts to handle process of fetching external JSON.
   useEffect(() => {
-    const {targetUrl, galagoParams} = getTargetUrlAndParams();
+    const { targetUrl, galagoParams } = getTargetUrlAndParams();
     if (targetUrl) {
       dispatch({
         type: ACTION_TYPES.FETCH_TREE_DATA_STARTED,

--- a/src/utils/fetchData.ts
+++ b/src/utils/fetchData.ts
@@ -4,6 +4,59 @@
 import { ROUTES } from "../routes";
 
 /**
+ * VOODOO_TODO__DOC_ME
+ */
+const SEARCH_PARAM_PREFIX = "galago";
+const ALL_GALAGO_PARAMS = [
+  'pathogen', // corresponding URL search param: `galagoPathogen`
+  'mrca', // corresponding URL search param: `galagoMrca`
+] as const;
+type AllGalagoParams = typeof ALL_GALAGO_PARAMS[number];
+// For actual usage downstream in app, we provide an object with the params as
+// keys, with the string value it had or `undefined` if not represented in URL.
+type GalagoParams = Partial<Record<AllGalagoParams, string>>
+// Helper to do internal name to URL search param: `fooBar` => `galagoFooBar`
+const internalToSearchParam = (param: string): string => {
+  return SEARCH_PARAM_PREFIX + param.charAt(0).toUpperCase() + param.slice(1);
+};
+
+interface ExtractedSearchParams {
+  galagoParams: GalagoParams;
+  remainingSearchString: string;
+}
+
+/**
+ * VOODOO_TODO__DOC_ME
+ */
+function extractSearchParams(searchString: string | undefined): ExtractedSearchParams {
+  const galagoParams: ExtractedSearchParams["galagoParams"] = {};
+  if (!searchString) { // There was no search portion. Just return defaults.
+    return {
+      galagoParams,
+      remainingSearchString: "",
+    };
+  }
+  // Fetch did have search params, handle them now.
+  const searchParams = new URLSearchParams(searchString);
+  ALL_GALAGO_PARAMS.forEach((internalParam) => {
+    const searchParamName = internalToSearchParam(internalParam);
+    const paramValue = searchParams.get(searchParamName);
+    if (paramValue !== null) {
+      galagoParams[internalParam] = paramValue;
+      searchParams.delete(searchParamName);
+    }
+  })
+  // At this point, whatever remains in `searchParams` was not for Galago's use
+  // If we used all of the search params, this will be an empty string.
+  const remainingSearchString = searchParams.toString();
+  return {
+    galagoParams,
+    remainingSearchString,
+  };
+}
+
+
+/**
  * If passed string does not have an http(s) schema already, prefix with https.
  *
  * We allow user to specify the URL they want a tree JSON fetched from, but we
@@ -23,6 +76,11 @@ function schemifyUrl(rawUrl: string): string {
   return result;
 }
 
+
+interface TargetUrlAndParams {
+  targetUrl: string; // Full URL for where we should go get JSON data
+  galagoParams: GalagoParams; // Set of (optional) query params about tree
+}
 /**
  * Gets the URL for external JSON tree from browser's current location.
  *
@@ -56,20 +114,40 @@ function schemifyUrl(rawUrl: string): string {
  * test where this would get called as part of it, look into "mocking window"
  * for javascript testing.
  */
-export function getUrlToFetch(): string {
+export function getTargetUrlAndParams(): TargetUrlAndParams {
+  // Return value for this func when fetch path was accessed incorrectly.
+  const MALFORMED_FETCH_RETURN_VAL: TargetUrlAndParams = {
+    targetUrl: "",
+    galagoParams: {},
+  };
+
+  // First, verify we're on the happy path for usage and get the fetch URL part
   const href = window.location.href; // Entire browser URL
   const fetchDeclarationIdx = href.indexOf(ROUTES.FETCH_DATA);
   if (fetchDeclarationIdx === -1) {
     // Fetch path not found
-    return "";
+    return MALFORMED_FETCH_RETURN_VAL;
   }
   // Above tells us where fetch path starts in href. To get the URL, we need to
   // skip to its end and then also go 1 farther to pass by the trailing `/`.
-  const fetchUrlIdx = fetchDeclarationIdx + ROUTES.FETCH_DATA.length + 1;
-  const fetchUrl = href.slice(fetchUrlIdx);
-  if (fetchUrl === "") {
+  const fetchHrefIdx = fetchDeclarationIdx + ROUTES.FETCH_DATA.length + 1;
+  const fetchTarget = href.slice(fetchHrefIdx);
+  if (fetchTarget === "") {
     // Fetch path found, but nothing given for data URL
-    return "";
+    return MALFORMED_FETCH_RETURN_VAL;
   }
-  return schemifyUrl(fetchUrl);
+
+  // Separate and handle any search params at end from rest of the fetch URL
+  const [preSearchUrl, searchString] = fetchTarget.split("?");
+  const { galagoParams, remainingSearchString } = extractSearchParams(searchString);
+  let targetUrl = preSearchUrl;
+  if (remainingSearchString) {
+    targetUrl = preSearchUrl + "?" + remainingSearchString;
+  }
+  targetUrl = schemifyUrl(targetUrl); // Ensure the URL we'll fetch has a schme
+
+  return {
+    targetUrl,
+    galagoParams,
+  };
 }

--- a/src/utils/fetchData.ts
+++ b/src/utils/fetchData.ts
@@ -29,20 +29,19 @@ const SEARCH_PARAM_PREFIX = "galago";
 const ALL_GALAGO_PARAMS = [
   // corresponding URL search param: `galagoPathogen`
   // Must be a key from src/utils/pathogenParameters `pathogenParameters`
-  'pathogen',
+  "pathogen",
   // corresponding URL search param: `galagoMrca`
   // TODO Implement usage of the param downstream in app.
-  'mrca',
+  "mrca",
 ] as const;
 type AllGalagoParams = typeof ALL_GALAGO_PARAMS[number];
 // For actual usage downstream in app, we provide an object with the params as
 // keys, with the string value it had or `undefined` if not represented in URL.
-export type GalagoParams = Partial<Record<AllGalagoParams, string>>
+export type GalagoParams = Partial<Record<AllGalagoParams, string>>;
 // Helper to do internal name to URL search param: `fooBar` => `galagoFooBar`
 const internalToSearchParam = (param: string): string => {
   return SEARCH_PARAM_PREFIX + param.charAt(0).toUpperCase() + param.slice(1);
 };
-
 
 interface ExtractedSearchParams {
   galagoParams: GalagoParams;
@@ -56,9 +55,12 @@ interface ExtractedSearchParams {
  * and also returns whatever portion of the URL search string was unused so
  * it can go back into being used as part of the fetch targetUrl.
  */
-function extractSearchParams(searchString: string | undefined): ExtractedSearchParams {
+function extractSearchParams(
+  searchString: string | undefined
+): ExtractedSearchParams {
   const galagoParams: ExtractedSearchParams["galagoParams"] = {};
-  if (!searchString) { // There was no search portion. Just return defaults.
+  if (!searchString) {
+    // There was no search portion. Just return defaults.
     return {
       galagoParams,
       remainingSearchString: "",
@@ -73,7 +75,7 @@ function extractSearchParams(searchString: string | undefined): ExtractedSearchP
       galagoParams[internalParam] = paramValue;
       searchParams.delete(searchParamName);
     }
-  })
+  });
   // At this point, whatever remains in `searchParams` was not for Galago's use
   // If we used all of the search params, this will be an empty string.
   const remainingSearchString = searchParams.toString();
@@ -82,7 +84,6 @@ function extractSearchParams(searchString: string | undefined): ExtractedSearchP
     remainingSearchString,
   };
 }
-
 
 /**
  * If passed string does not have an http(s) schema already, prefix with https.
@@ -103,7 +104,6 @@ function schemifyUrl(rawUrl: string): string {
   }
   return result;
 }
-
 
 interface TargetUrlAndParams {
   targetUrl: string; // Full URL for where we should go get JSON data
@@ -170,7 +170,8 @@ export function getTargetUrlAndParams(): TargetUrlAndParams {
   // We must handle the `?` splitting manually as `location.search` won't work
   // due to majority of URL being behind `#` (b/c HashRouter for GitHub Pages).
   const [preSearchUrl, searchString] = fetchTarget.split("?");
-  const { galagoParams, remainingSearchString } = extractSearchParams(searchString);
+  const { galagoParams, remainingSearchString } =
+    extractSearchParams(searchString);
   let targetUrl = preSearchUrl;
   if (remainingSearchString) {
     targetUrl = preSearchUrl + "?" + remainingSearchString;


### PR DESCRIPTION
Puts an approach in place for handling https://github.com/chanzuckerberg/galago/issues/186 .

**Only actually handles pathogen** right now. This is mostly about putting in a process for building search (AKA query) params out over time. Right now there is a stub for pulling in `galagoMrca` / `mrca` value, but nothing downstream in the reducer actually uses that param value. Location stuff is untouched with this, but I think it should be pretty easy to build on this to add params as needed. Just need to add in the param to `ALL_GALAGO_PARAMS`, then insert handling logic in the `FETCH_TREE_DATA_SUCCEEDED` reducer func.