### PR TITLE
Fix overlapping UI elements

### DIFF
--- a/src/components/viz/cladeSelection/cladeSelectionVizControls.tsx
+++ b/src/components/viz/cladeSelection/cladeSelectionVizControls.tsx
@@ -1,9 +1,7 @@
 import { useSelector, useDispatch } from "react-redux";
-import { Button, Drawer, Tooltip, useTheme } from "@mui/material";
+import { Button, Tooltip } from "@mui/material";
 import CladeFilterDrawer from "../../cladeFilterDrawer";
-import { useWindowSize } from "@react-hook/window-size";
 import { tooltipProps } from "../../formatters/sidenote";
-import { useState } from "react";
 import CladeSelector from "./cladeSelector";
 import CladeSlider from "./cladeSlider";
 
@@ -15,15 +13,12 @@ export const CladeSelectionVizControls = (
   props: CladeSelectionVizControlsProps
 ) => {
   const { sectionWidth } = props;
-  const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
-  const [windowWidth, windowHeight] = useWindowSize();
 
   //@ts-ignore
   const state = useSelector((state) => state.global);
   const dispatch = useDispatch();
 
   const getFilterButtonTooltipText = () => {
-    const theme = useTheme();
     if (state.samplesOfInterestNames.length || state.clusteringMethod) {
       return `Samples of interest: ${state.samplesOfInterestNames.length}  |
   Clustering: ${state.clusteringMethod ? state.clusteringMethod : "none"}
@@ -45,7 +40,6 @@ export const CladeSelectionVizControls = (
         justifyContent: "space-evenly",
         position: "relative",
         width: sectionWidth,
-        // paddingLeft: 25,
         // border: "1px solid purple",
       }}
     >
@@ -66,7 +60,6 @@ export const CladeSelectionVizControls = (
             sx={{
               fontSize: 10,
               margin: 0,
-              // width: 50,
             }}
             variant="contained"
           >

--- a/src/components/viz/cladeSelection/cladeSelector.tsx
+++ b/src/components/viz/cladeSelection/cladeSelector.tsx
@@ -33,7 +33,6 @@ export const CladeSelector = (props?: CladeSelectorProps) => {
     const tipCount = getNodeAttr(mrca, "tipCount");
     const niceName = mrca.name.replace("NODE_", "Clade ");
     return niceName;
-    // return tipCount ? `${niceName} (${tipCount} samples)` : niceName;
   };
 
   const formatSelectorOptions = () => {

--- a/src/components/viz/cladeSelection/cladeSlider.tsx
+++ b/src/components/viz/cladeSelection/cladeSlider.tsx
@@ -86,7 +86,6 @@ export const CladeSlider = (props: CladeSliderProps) => {
       <Slider
         //@ts-ignore
         sx={{
-          // width: sectionWidth - 100,
           "& .MuiSlider-thumb": {
             opacity: 0.7,
           },

--- a/src/components/viz/cladeSelection/index.tsx
+++ b/src/components/viz/cladeSelection/index.tsx
@@ -8,6 +8,7 @@ import uuid from "react-uuid";
 import CladeSelectionVizControls from "./cladeSelectionVizControls";
 import CladeSelectionVizLegend from "./scatterplotLegend";
 import { Theme } from "../../../theme";
+import { timeFormat } from "d3-time-format";
 
 type CladeSelectionVizProps = {
   chartHeight: number;
@@ -193,6 +194,8 @@ export const CladeSelectionViz = (props: CladeSelectionVizProps) => {
             top={scatterplotHeight - chartMargin}
             scale={_xScaleTime}
             numTicks={9}
+            //@ts-ignore
+            tickFormat={(tick: Date) => timeFormat("%m/%y")(tick)}
           />
         </svg>
       </div>

--- a/src/components/viz/cladeSelection/index.tsx
+++ b/src/components/viz/cladeSelection/index.tsx
@@ -181,7 +181,7 @@ export const CladeSelectionViz = (props: CladeSelectionVizProps) => {
             })
             .map((sample) => plotSample(sample))}
 
-          <CladeSelectionVizLegend />
+          <CladeSelectionVizLegend smallWindow={chartHeight < 200} />
           <AxisLeft
             strokeWidth={0}
             left={chartMargin * 2}

--- a/src/components/viz/cladeSelection/index.tsx
+++ b/src/components/viz/cladeSelection/index.tsx
@@ -2,7 +2,7 @@ import { Node } from "../../../d";
 import { get_leaves, traverse_preorder } from "../../../utils/treeMethods";
 import { scaleLinear, extent, scaleTime, symbolCross } from "d3";
 import { AxisLeft, AxisBottom } from "@visx/axis";
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector } from "react-redux";
 //@ts-ignore
 import uuid from "react-uuid";
 import CladeSelectionVizControls from "./cladeSelectionVizControls";

--- a/src/components/viz/cladeSelection/scatterplotLegend.tsx
+++ b/src/components/viz/cladeSelection/scatterplotLegend.tsx
@@ -16,7 +16,7 @@ export const CladeSelectionVizLegend = (
       {legendOpen ? (
         <g
           id="interactive-sample-selection-legend"
-          transform="translate(150,85)"
+          transform="translate(100,50)"
         >
           <text y={-10} onClick={() => setLegendOpen(false)}>
             Legend &#9650;
@@ -68,7 +68,7 @@ export const CladeSelectionVizLegend = (
       ) : (
         <g
           id="interactive-sample-selection-legend"
-          transform="translate(150,85)"
+          transform="translate(100,50)"
         >
           <text y={-10} onClick={() => setLegendOpen(true)}>
             Legend &#9660;

--- a/src/components/viz/cladeSelection/scatterplotLegend.tsx
+++ b/src/components/viz/cladeSelection/scatterplotLegend.tsx
@@ -1,54 +1,81 @@
 import ColorLensIcon from "@mui/icons-material/ColorLens";
 import Theme from "../../../theme";
+import { useState } from "react";
 
-export const CladeSelectionVizLegend = () => {
+type CladeSelectionVizLegendProps = {
+  smallWindow: boolean;
+};
+
+export const CladeSelectionVizLegend = (
+  props: CladeSelectionVizLegendProps
+) => {
+  const { smallWindow } = props;
+  const [legendOpen, setLegendOpen] = useState(!smallWindow);
+
   return (
     <>
-      <g id="interactive-sample-selection-legend" transform="translate(150,85)">
-        <circle cx="0" cy="7" r={3} fill={Theme.palette.secondary.main} />
-        <text x="10" y="10" fontSize={14}>
-          Other samples
-        </text>
-        <g transform={`translate(0,26.5)`}>
-          <line x1="-4" y1="0" x2="4" y2="0" stroke="black" strokeWidth={1} />
-          <line x1="0" y1="-4" x2="0" y2="4" stroke="black" strokeWidth={1} />
-        </g>
-        <text x="10" y="30" fontSize={14}>
-          Your samples of interest
-        </text>
-        <circle
-          cx="0"
-          cy="47"
-          r={3}
-          fill={Theme.palette.primary.light}
-          stroke={Theme.palette.secondary.dark}
-          strokeWidth={1}
-        />
-        <text x="10" y="50" fontSize={14}>
-          Other samples in active cluster
-        </text>
-        <g transform={`translate(0,66.5)`}>
-          <line
-            x1="-4"
-            y1="0"
-            x2="4"
-            y2="0"
-            stroke={Theme.palette.primary.main}
-            strokeWidth={3}
+      {legendOpen ? (
+        <g
+          id="interactive-sample-selection-legend"
+          transform="translate(150,85)"
+        >
+          <text y={-10} onClick={() => setLegendOpen(false)}>
+            Legend &#9650;
+          </text>
+          <circle cx="0" cy="7" r={3} fill={Theme.palette.secondary.main} />
+          <text x="10" y="10" fontSize={14}>
+            Other samples
+          </text>
+          <g transform={`translate(0,26.5)`}>
+            <line x1="-4" y1="0" x2="4" y2="0" stroke="black" strokeWidth={1} />
+            <line x1="0" y1="-4" x2="0" y2="4" stroke="black" strokeWidth={1} />
+          </g>
+          <text x="10" y="30" fontSize={14}>
+            Your samples of interest
+          </text>
+          <circle
+            cx="0"
+            cy="47"
+            r={3}
+            fill={Theme.palette.primary.light}
+            stroke={Theme.palette.secondary.dark}
+            strokeWidth={1}
           />
-          <line
-            x1="0"
-            y1="-4"
-            x2="0"
-            y2="4"
-            stroke={Theme.palette.primary.main}
-            strokeWidth={3}
-          />
+          <text x="10" y="50" fontSize={14}>
+            Other samples in active cluster
+          </text>
+          <g transform={`translate(0,66.5)`}>
+            <line
+              x1="-4"
+              y1="0"
+              x2="4"
+              y2="0"
+              stroke={Theme.palette.primary.main}
+              strokeWidth={3}
+            />
+            <line
+              x1="0"
+              y1="-4"
+              x2="0"
+              y2="4"
+              stroke={Theme.palette.primary.main}
+              strokeWidth={3}
+            />
+          </g>
+          <text x="10" y="70" fontSize={14}>
+            Your samples of interest in active cluster
+          </text>
         </g>
-        <text x="10" y="70" fontSize={14}>
-          Your samples of interest in active cluster
-        </text>
-      </g>
+      ) : (
+        <g
+          id="interactive-sample-selection-legend"
+          transform="translate(150,85)"
+        >
+          <text y={-10} onClick={() => setLegendOpen(true)}>
+            Legend &#9660;
+          </text>
+        </g>
+      )}
     </>
   );
 };

--- a/src/components/viz/cladeSelection/scatterplotLegend.tsx
+++ b/src/components/viz/cladeSelection/scatterplotLegend.tsx
@@ -1,4 +1,3 @@
-import ColorLensIcon from "@mui/icons-material/ColorLens";
 import Theme from "../../../theme";
 import { useState } from "react";
 

--- a/src/components/viz/epiCurve.tsx
+++ b/src/components/viz/epiCurve.tsx
@@ -223,49 +223,48 @@ export const EpiCurve = (props: EpiCurveProps) => {
       style={{
         position: "relative",
         width: chartWidth,
-        borderColor: "red",
-        borderWidth: 2,
       }}
     >
-      <div style={{ position: "relative", top: 10, left: 20 }}>
-        <ToggleButtonGroup
-          value={colorBy}
-          exclusive
-          onChange={handleColorbySelection}
-          aria-label="color by"
-        >
-          <ToggleButton
-            value="transmissions"
-            aria-label="transmissions"
-            style={{ width: 30, height: 30 }}
-          >
-            <TimelineIcon />
-          </ToggleButton>
-          <ToggleButton
-            value="geography"
-            aria-label="geography"
-            style={{ width: 30, height: 30 }}
-          >
-            <MapIcon />
-          </ToggleButton>
-        </ToggleButtonGroup>
-      </div>
       <div
         style={{
-          position: "absolute",
-          top: chartMargin / 2 - 10,
-          left: 60,
-          width: "100%",
           display: "flex",
-          justifyContent: "center",
-          fontSize: "11px",
+          flexDirection: "row",
+          justifyContent: "space-evenly",
+          width: chartWidth,
         }}
       >
-        <LegendOrdinal
-          scale={colorScale}
-          direction="row"
-          labelMargin="0 15px 0 0"
-        />
+        <div style={{ width: 60 }}>
+          <ToggleButtonGroup
+            value={colorBy}
+            exclusive
+            onChange={handleColorbySelection}
+            aria-label="color by"
+          >
+            <ToggleButton
+              value="transmissions"
+              aria-label="transmissions"
+              style={{ width: 30, height: 30 }}
+            >
+              <TimelineIcon />
+            </ToggleButton>
+            <ToggleButton
+              value="geography"
+              aria-label="geography"
+              style={{ width: 30, height: 30 }}
+            >
+              <MapIcon />
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </div>
+        <div
+          style={{
+            fontSize: "11px",
+            width: chartWidth - 80,
+            position: "relative",
+          }}
+        >
+          <LegendOrdinal scale={colorScale} direction="row" />
+        </div>
       </div>
 
       <svg width={chartWidth} height={chartHeight - 50}>

--- a/src/components/viz/epiCurve.tsx
+++ b/src/components/viz/epiCurve.tsx
@@ -1,15 +1,11 @@
-import * as d3 from "d3";
-import { Label, Connector, CircleSubject, Annotation } from "@visx/annotation";
-import { LinePath } from "@visx/shape";
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector } from "react-redux";
 import React, { useState } from "react";
 import { BarStack } from "@visx/shape";
-import { SeriesPoint } from "@visx/shape/lib/types";
 import { Group } from "@visx/group";
 import { GridRows } from "@visx/grid";
 import { AxisBottom, AxisLeft } from "@visx/axis";
 import { scaleBand, scaleLinear, scaleOrdinal } from "@visx/scale";
-import { timeParse, timeFormat } from "d3-time-format";
+import { timeFormat } from "d3-time-format";
 // import { useTooltip, useTooltipInPortal, defaultStyles } from '@visx/tooltip';
 import { LegendOrdinal } from "@visx/legend";
 import ToggleButton from "@mui/material/ToggleButton";
@@ -22,7 +18,7 @@ import {
   traverse_preorder,
 } from "../../utils/treeMethods";
 import { Node } from "../../d";
-import { color, range, scaleTime } from "d3";
+import { range } from "d3";
 import {
   binMonthlyDate,
   binWeeklyDate,
@@ -231,18 +227,25 @@ export const EpiCurve = (props: EpiCurveProps) => {
         borderWidth: 2,
       }}
     >
-      <div style={{ position: "absolute", top: 0 }}>
+      <div style={{ position: "relative", top: 10, left: 20 }}>
         <ToggleButtonGroup
           value={colorBy}
           exclusive
           onChange={handleColorbySelection}
           aria-label="color by"
-          size="small"
         >
-          <ToggleButton value="transmissions" aria-label="transmissions">
+          <ToggleButton
+            value="transmissions"
+            aria-label="transmissions"
+            style={{ width: 30, height: 30 }}
+          >
             <TimelineIcon />
           </ToggleButton>
-          <ToggleButton value="geography" aria-label="geography">
+          <ToggleButton
+            value="geography"
+            aria-label="geography"
+            style={{ width: 30, height: 30 }}
+          >
             <MapIcon />
           </ToggleButton>
         </ToggleButtonGroup>
@@ -348,7 +351,7 @@ export const EpiCurve = (props: EpiCurveProps) => {
           scale={countScale}
           width={xMax}
           height={yMax}
-          stroke={gridValues !== [] ? "white" : Theme.palette.secondary.main}
+          stroke={"white"}
           strokeOpacity={1}
           tickValues={gridValues}
         />

--- a/src/components/viz/epiCurve.tsx
+++ b/src/components/viz/epiCurve.tsx
@@ -73,7 +73,7 @@ export const EpiCurve = (props: EpiCurveProps) => {
     return binDate(getNodeAttr(node, "num_date"));
   };
 
-  let dateFormatString = binScale === "monthly" ? "%b" : "%b %d";
+  let dateFormatString = binScale === "monthly" ? "%m/%y" : "%d/%m/%y";
 
   const formatDate = (date: Date) => {
     return timeFormat(dateFormatString)(date);

--- a/src/components/viz/unrootedTree/index.tsx
+++ b/src/components/viz/unrootedTree/index.tsx
@@ -81,7 +81,10 @@ export const unrootedTree = (props: unrootedTreeProps) => {
             scaleDomainR={scaleDomainR}
             tooltip={tooltip}
           />
-          <UnrootedTreeLegend colorScale={colorScale} />
+          <UnrootedTreeLegend
+            colorScale={colorScale}
+            smallWindow={chartHeight < 200}
+          />
         </svg>
       )}
       {ready && tooltip.tooltipOpen && tooltip.tooltipData && (

--- a/src/components/viz/unrootedTree/unrootedTreeLegend.tsx
+++ b/src/components/viz/unrootedTree/unrootedTreeLegend.tsx
@@ -1,13 +1,17 @@
 import { useSelector } from "react-redux";
+import { useState } from "react";
 
 type UnrootedTreeLegendProps = {
   colorScale: string[];
+  smallWindow: boolean;
 };
 
 export const UnrootedTreeLegend = (props: UnrootedTreeLegendProps) => {
-  const { colorScale } = props;
+  const { colorScale, smallWindow } = props;
+  const [legendOpen, setLegendOpen] = useState(!smallWindow);
+
   const legendWidth = 195;
-  const legendHeight = 160;
+  const legendHeight = legendOpen ? 160 : 50;
   //@ts-ignore
   const state = useSelector((state) => state.global);
 
@@ -54,59 +58,63 @@ export const UnrootedTreeLegend = (props: UnrootedTreeLegendProps) => {
   };
 
   return (
-    <g id="unrooted-tree-legend">
-      <g id="color-bar">
-        <rect
-          x={0}
-          y={0}
-          width={legendWidth}
-          height={legendHeight}
-          fill="white"
-          opacity={0.8}
-        />
-        {colorScale.map((cs, i) => drawColorScaleSegment(cs, i))}
-        <text x={paddingX} y={paddingY} fontSize={10}>
-          Distance from putative primary case
-        </text>
-      </g>
-      <g id="primary-case">
-        <rect
-          x={paddingX}
-          y={markerStartY}
-          width={glyphWidth}
-          height={glyphWidth}
-          fill={"lightGray"}
-          stroke="darkGray"
-        />
-        <text
-          x={textX}
-          y={markerStartY + glyphHeight / 2}
-          fontSize={10}
-          dominantBaseline="middle"
-        >
-          Includes sample(s) of interest
-        </text>
-      </g>
-      <g id="other samples">
-        <circle
-          cx={glyphCenterX}
-          cy={markerStartY + glyphHeight + paddingY}
-          r={glyphWidth / 1.85}
-          fill="lightGray"
-          stroke="darkGray"
-        />
+    <>
+      {legendOpen ? (
+        <g id="unrooted-tree-legend" transform="translate(35,35)">
+          <g id="color-bar">
+            <rect
+              y={-25} // cheating -- offset for including title
+              width={legendWidth}
+              height={legendHeight + 25}
+              fill="white"
+              opacity={0.8}
+            />
+            <text y={-10} onClick={() => setLegendOpen(false)}>
+              Legend &#9650;
+            </text>
+            {colorScale.map((cs, i) => drawColorScaleSegment(cs, i))}
+            <text x={paddingX} y={paddingY} fontSize={10}>
+              Distance from putative primary case
+            </text>
+          </g>
+          <g id="primary-case">
+            <rect
+              x={paddingX}
+              y={markerStartY}
+              width={glyphWidth}
+              height={glyphWidth}
+              fill={"lightGray"}
+              stroke="darkGray"
+            />
+            <text
+              x={textX}
+              y={markerStartY + glyphHeight / 2}
+              fontSize={10}
+              dominantBaseline="middle"
+            >
+              Includes sample(s) of interest
+            </text>
+          </g>
+          <g id="other samples">
+            <circle
+              cx={glyphCenterX}
+              cy={markerStartY + glyphHeight + paddingY}
+              r={glyphWidth / 1.85}
+              fill="lightGray"
+              stroke="darkGray"
+            />
 
-        <text
-          x={textX}
-          y={markerStartY + glyphHeight + paddingY}
-          dominantBaseline="middle"
-          fontSize={10}
-        >
-          Other samples
-        </text>
-      </g>
+            <text
+              x={textX}
+              y={markerStartY + glyphHeight + paddingY}
+              dominantBaseline="middle"
+              fontSize={10}
+            >
+              Other samples
+            </text>
+          </g>
 
-      {/* <line
+          {/* <line
         x1={paddingX}
         x2={paddingX + tickBarLength}
         y1={tickBarStartY}
@@ -134,7 +142,7 @@ export const UnrootedTreeLegend = (props: UnrootedTreeLegendProps) => {
         y2={tickBarStartY - glyphHeight / 2}
         stroke="darkgray"
       /> */}
-      {/* <text
+          {/* <text
         x={paddingX}
         y={tickBarStartY + glyphHeight + paddingY}
         dominantBaseline="bottom"
@@ -143,7 +151,22 @@ export const UnrootedTreeLegend = (props: UnrootedTreeLegendProps) => {
       >
         Ticks each 1 mutation
       </text> */}
-    </g>
+        </g>
+      ) : (
+        <g transform="translate(35,35)">
+          <rect
+            y={-25} // cheating -- offset for including title
+            width={80}
+            height={25}
+            fill="white"
+            opacity={0.8}
+          />
+          <text y={-10} onClick={() => setLegendOpen(true)}>
+            Legend &#9660;
+          </text>
+        </g>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
Addressing Liz's feedback that on small laptop screens there were overlapping UI elements. Changes: 
- Legend on tree and scatterplot are collapsible
- Scatterplot legend is positioned closer to upper left
- Epi curve controls + legend are in a nice flexbox
- Epi curve controls are smaller
- X axes for scatterplot and epi curve are in more succinct formats to avoid (as much) text overlap

<img width="1240" alt="image" src="https://user-images.githubusercontent.com/12618847/192073730-0a949386-a8ef-4a08-867a-273fc4a9781a.png">
